### PR TITLE
created terraform to provision infra to deploy CRE on aws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,14 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 
-
 tutorial.md
 .vscode
+
+# Terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+
+

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,15 +5,17 @@
  */
 
 exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
-  if (stage === "build-html") {
-    actions.setWebpackConfig({
-      resolve: {
-        alias: {
-          // Use a mock for react-resize-aware during SSR
-          // to prevent errors with browser-specific code.
-          'react-resize-aware': require.resolve('./src/mocks/react-resize-aware.js'),
-        },
+ 
+  actions.setWebpackConfig({
+    resolve: {
+      alias: {
+        'react-resize-aware': require.resolve('./src/mocks/react-resize-aware.js'),
       },
+    },
+  })
+
+  if (stage === 'build-html') {
+    actions.setWebpackConfig({
       module: {
         rules: [
           {

--- a/src/mocks/react-resize-aware.js
+++ b/src/mocks/react-resize-aware.js
@@ -1,9 +1,14 @@
-// src/mocks/react-resize-aware.js
-// This mock is used during SSR (build-html stage in Gatsby)
-// to prevent errors with browser-specific code.
 
-const mockResizeListener = () => {}; // A no-op function for the listener element
-const mockSizes = { width: 0, height: 0 }; // Default sizes
+
+import React from "react"
+
+const mockResizeListener = React.createElement("div", {
+  style: { display: "none" },
+  key: "mock-resize-listener"
+});
+
+// Default sizes that will be returned by the hook
+const mockSizes = { width: 1024, height: 768 };
 
 // Export a function that mimics the useResizeAware hook's signature
 const useMockResizeAware = () => [mockResizeListener, mockSizes];

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  backend "s3" {
+    bucket         = "cre-terraform-state-dev"
+    key            = "dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "cre-terraform-locks"
+    encrypt        = true
+  }
+}
+
+module "infrastructure" {
+  source = "../../"
+  
+  project_name = "community-resource-explorer"
+  environment  = "dev"
+  # domain_name  = null  # Use CloudFront default domain
+  
+  # Environment variables: populate via terraform.tfvars
+  mapbox_api_token = var.mapbox_api_token
+  ga_tracking_id   = var.ga_tracking_id  
+  mapbox_user      = var.mapbox_user
+}

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -1,0 +1,24 @@
+output "website_url" {
+  description = "Website URL"
+  value       = module.infrastructure.website_url
+}
+
+output "s3_bucket_name" {
+  description = "S3 bucket name for static hosting"
+  value       = module.infrastructure.s3_bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = module.infrastructure.cloudfront_distribution_id
+}
+
+output "route53_name_servers" {
+  description = "Route 53 name servers"
+  value       = module.infrastructure.route53_name_servers
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = module.infrastructure.cloudfront_domain_name
+}

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Copy this file to terraform.tfvars and fill in your values
+# DO NOT commit terraform.tfvars to version control
+
+# AWS Configuration
+aws_region = "us-east-2"  # for dev
+
+# Application Secrets
+mapbox_api_token = "your_mapbox_token_here"
+ga_tracking_id   = "your_ga_tracking_id_here"
+mapbox_user      = "your_mapbox_username_here"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,20 @@
+variable "mapbox_api_token" {
+  description = "Mapbox API token for maps functionality"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "ga_tracking_id" {
+  description = "Google Analytics tracking ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "mapbox_user" {
+  description = "Mapbox username"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  backend "s3" {
+    bucket         = "cre-terraform-state-prod"
+    key            = "prod/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "cre-terraform-locks"
+    encrypt        = true
+  }
+}
+
+module "infrastructure" {
+  source = "../../"
+  
+  project_name = "community-resource-explorer"
+  environment  = "prod"
+  # domain_name  = null  # Use CloudFront default domain
+  
+  # Environment variables - populate via terraform.tfvars
+  mapbox_api_token = var.mapbox_api_token
+  ga_tracking_id   = var.ga_tracking_id  
+  mapbox_user      = var.mapbox_user
+}

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -1,0 +1,24 @@
+output "website_url" {
+  description = "Website URL"
+  value       = module.infrastructure.website_url
+}
+
+output "s3_bucket_name" {
+  description = "S3 bucket name for static hosting"
+  value       = module.infrastructure.s3_bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = module.infrastructure.cloudfront_distribution_id
+}
+
+output "route53_name_servers" {
+  description = "Route 53 name servers"
+  value       = module.infrastructure.route53_name_servers
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = module.infrastructure.cloudfront_domain_name
+}

--- a/terraform/environments/prod/terraform.tfvars.example
+++ b/terraform/environments/prod/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Copy this file to terraform.tfvars and fill in your values
+
+# AWS Configuration
+aws_region = "us-east-1"  # for prod
+
+# Application Secrets
+mapbox_api_token = "your_mapbox_token_here"
+ga_tracking_id   = "your_ga_tracking_id_here"
+mapbox_user      = "your_mapbox_username_here"
+
+# CloudFront price class override for production
+price_class = "PriceClass_All"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,17 @@
+variable "mapbox_api_token" {
+  description = "Mapbox API token for maps functionality"
+  type        = string
+  sensitive   = true
+}
+
+variable "ga_tracking_id" {
+  description = "Google Analytics tracking ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "mapbox_user" {
+  description = "Mapbox username"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  
+  default_tags {
+    tags = {
+      Project     = var.project_name
+      Environment = var.environment
+      ManagedBy   = "terraform"
+    }
+  }
+}
+
+# S3 and CloudFront for static hosting
+module "static_hosting" {
+  source = "./modules/s3-cloudfront"
+  
+  project_name  = var.project_name
+  environment   = var.environment
+  domain_name   = var.domain_name
+  aws_region    = var.aws_region
+  price_class   = var.price_class
+}
+
+# Route 53 for DNS management (only when domain is specified)
+module "route53" {
+  count  = var.domain_name != null ? 1 : 0
+  source = "./modules/route53"
+  
+  domain_name            = var.domain_name
+  cloudfront_domain_name = module.static_hosting.cloudfront_domain_name
+  cloudfront_zone_id     = module.static_hosting.cloudfront_zone_id
+  environment           = var.environment
+}
+
+# Secrets Manager for environment variables
+module "secrets" {
+  source = "./modules/secrets"
+  
+  project_name = var.project_name
+  environment  = var.environment
+  secrets = {
+    mapbox_api_token = var.mapbox_api_token
+    ga_tracking_id   = var.ga_tracking_id
+    mapbox_user      = var.mapbox_user
+  }
+}
+
+# Monitoring and alerting
+module "monitoring" {
+  source = "./modules/monitoring"
+  
+  project_name           = var.project_name
+  environment           = var.environment
+  s3_bucket_name        = module.static_hosting.s3_bucket_name
+  cloudfront_distribution_id = module.static_hosting.cloudfront_distribution_id
+  aws_region                = var.aws_region
+}

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,0 +1,141 @@
+# CloudWatch Log Group for general application logs
+resource "aws_cloudwatch_log_group" "app_logs" {
+  name              = "/aws/${var.project_name}/${var.environment}"
+  retention_in_days = var.environment == "prod" ? 30 : 7
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-logs"
+  }
+}
+
+# CloudWatch Dashboard
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${var.project_name}-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+
+        properties = {
+          metrics = [
+            ["AWS/CloudFront", "Requests", "DistributionId", var.cloudfront_distribution_id],
+            [".", "BytesDownloaded", ".", "."],
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = "us-east-1"
+          title   = "CloudFront Requests and Data Transfer"
+          period  = 300
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+
+        properties = {
+          metrics = [
+            ["AWS/CloudFront", "4xxErrorRate", "DistributionId", var.cloudfront_distribution_id],
+            [".", "5xxErrorRate", ".", "."],
+          ]
+          view    = "timeSeries"
+          stacked = false
+          region  = "us-east-1"
+          title   = "CloudFront Error Rates"
+          period  = 300
+        }
+      }
+    ]
+  })
+}
+
+# CloudWatch Alarms
+resource "aws_cloudwatch_metric_alarm" "high_4xx_error_rate" {
+  alarm_name          = "${var.project_name}-${var.environment}-high-4xx-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "4xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "5"
+  alarm_description   = "This metric monitors 4xx error rate"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DistributionId = var.cloudfront_distribution_id
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-4xx-alarm"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_5xx_error_rate" {
+  alarm_name          = "${var.project_name}-${var.environment}-high-5xx-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "5xxErrorRate"
+  namespace           = "AWS/CloudFront"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "1"
+  alarm_description   = "This metric monitors 5xx error rate"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    DistributionId = var.cloudfront_distribution_id
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-5xx-alarm"
+  }
+}
+
+# SNS Topic for alerts
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project_name}-${var.environment}-alerts"
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-alerts"
+  }
+}
+
+# Budget Alert
+resource "aws_budgets_budget" "cost_budget" {
+  count = var.environment == "prod" ? 1 : 0
+  
+  name         = "${var.project_name}-${var.environment}-budget"
+  budget_type  = "COST"
+  limit_amount = "50"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_filter {
+    name = "TagKeyValue"
+    values = ["Project$${var.project_name}"]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                 = 80
+    threshold_type            = "PERCENTAGE"
+    notification_type         = "ACTUAL"
+    subscriber_email_addresses = []
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                 = 100
+    threshold_type            = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = []
+  }
+}

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -1,0 +1,14 @@
+output "dashboard_url" {
+  description = "CloudWatch dashboard URL"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#dashboards:name=${aws_cloudwatch_dashboard.main.dashboard_name}"
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for alerts"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "log_group_arn" {
+  description = "CloudWatch log group ARN"
+  value       = aws_cloudwatch_log_group.app_logs.arn
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,24 @@
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  type        = string
+}

--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -1,0 +1,48 @@
+# Route 53 Hosted Zone
+resource "aws_route53_zone" "main" {
+  name = var.domain_name
+
+  tags = {
+    Name = "${var.domain_name}-zone"
+    Environment = var.environment
+  }
+}
+
+# A record for the main domain
+resource "aws_route53_record" "main" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# AAAA record for IPv6 support
+resource "aws_route53_record" "main_ipv6" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "AAAA"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# WWW redirect (optional)
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = var.cloudfront_domain_name
+    zone_id                = var.cloudfront_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/modules/route53/outputs.tf
+++ b/terraform/modules/route53/outputs.tf
@@ -1,0 +1,14 @@
+output "zone_id" {
+  description = "Route 53 hosted zone ID"
+  value       = aws_route53_zone.main.zone_id
+}
+
+output "name_servers" {
+  description = "Route 53 name servers"
+  value       = aws_route53_zone.main.name_servers
+}
+
+output "zone_arn" {
+  description = "Route 53 hosted zone ARN"
+  value       = aws_route53_zone.main.arn
+}

--- a/terraform/modules/route53/variables.tf
+++ b/terraform/modules/route53/variables.tf
@@ -1,0 +1,19 @@
+variable "domain_name" {
+  description = "Domain name for the hosted zone"
+  type        = string
+}
+
+variable "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  type        = string
+}
+
+variable "cloudfront_zone_id" {
+  description = "CloudFront distribution zone ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}

--- a/terraform/modules/s3-cloudfront/main.tf
+++ b/terraform/modules/s3-cloudfront/main.tf
@@ -1,0 +1,183 @@
+# S3 bucket for static website hosting
+resource "aws_s3_bucket" "website" {
+  bucket = "${var.project_name}-${var.environment}-static"
+}
+
+resource "aws_s3_bucket_public_access_block" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# CloudFront Origin Access Control
+resource "aws_cloudfront_origin_access_control" "website" {
+  name                              = "${var.project_name}-${var.environment}-oac"
+  description                       = "OAC for ${var.project_name} ${var.environment}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+# ACM Certificate for CloudFront (only when domain is specified)
+resource "aws_acm_certificate" "website" {
+  count = var.domain_name != null ? 1 : 0
+  
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  subject_alternative_names = [
+    "*.${var.domain_name}"
+  ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# CloudFront Distribution
+resource "aws_cloudfront_distribution" "website" {
+  origin {
+    domain_name              = aws_s3_bucket.website.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.website.id
+    origin_id                = "S3-${aws_s3_bucket.website.bucket}"
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.project_name} ${var.environment} distribution"
+  default_root_object = "index.html"
+
+  aliases = var.domain_name != null ? [var.domain_name] : []
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3-${aws_s3_bucket.website.bucket}"
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  # Cache behavior for static assets
+  ordered_cache_behavior {
+    path_pattern     = "/static/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "S3-${aws_s3_bucket.website.bucket}"
+    compress         = true
+
+    forwarded_values {
+      query_string = false
+      headers      = ["Origin"]
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 31536000  # 1 year
+    max_ttl                = 31536000  # 1 year
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # Cache behavior for page-data (Gatsby specific)
+  ordered_cache_behavior {
+    path_pattern     = "/page-data/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "S3-${aws_s3_bucket.website.bucket}"
+    compress         = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    min_ttl                = 0
+    default_ttl            = 0
+    max_ttl                = 31536000
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  price_class = var.price_class
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = var.domain_name != null ? aws_acm_certificate.website[0].arn : null
+    ssl_support_method       = var.domain_name != null ? "sni-only" : null
+    minimum_protocol_version = var.domain_name != null ? "TLSv1.2_2021" : null
+    cloudfront_default_certificate = var.domain_name == null ? true : false
+  }
+
+  custom_error_response {
+    error_code         = 404
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  custom_error_response {
+    error_code         = 403
+    response_code      = 404
+    response_page_path = "/404.html"
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-distribution"
+  }
+}
+
+# S3 bucket policy to allow CloudFront access
+resource "aws_s3_bucket_policy" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontServicePrincipal"
+        Effect    = "Allow"
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        }
+        Action   = "s3:GetObject"
+        Resource = "${aws_s3_bucket.website.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.website.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/s3-cloudfront/outputs.tf
+++ b/terraform/modules/s3-cloudfront/outputs.tf
@@ -1,0 +1,29 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.website.bucket
+}
+
+output "s3_bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.website.arn
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = aws_cloudfront_distribution.website.id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.website.domain_name
+}
+
+output "cloudfront_zone_id" {
+  description = "CloudFront distribution zone ID"
+  value       = aws_cloudfront_distribution.website.hosted_zone_id
+}
+
+output "acm_certificate_arn" {
+  description = "ACM certificate ARN"
+  value       = var.domain_name != null ? aws_acm_certificate.website[0].arn : null
+}

--- a/terraform/modules/s3-cloudfront/variables.tf
+++ b/terraform/modules/s3-cloudfront/variables.tf
@@ -1,0 +1,25 @@
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name for the website"
+  type        = string
+}
+
+variable "price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}

--- a/terraform/modules/secrets/main.tf
+++ b/terraform/modules/secrets/main.tf
@@ -1,0 +1,88 @@
+# Secrets Manager secrets for environment variables
+resource "aws_secretsmanager_secret" "mapbox_api_token" {
+  name                    = "${var.project_name}/${var.environment}/mapbox-api-token"
+  description             = "Mapbox API token for ${var.project_name} ${var.environment}"
+  recovery_window_in_days = var.environment == "prod" ? 30 : 0
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-mapbox-token"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "mapbox_api_token" {
+  count         = var.secrets.mapbox_api_token != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.mapbox_api_token.id
+  secret_string = var.secrets.mapbox_api_token
+}
+
+resource "aws_secretsmanager_secret" "ga_tracking_id" {
+  name                    = "${var.project_name}/${var.environment}/ga-tracking-id"
+  description             = "Google Analytics tracking ID for ${var.project_name} ${var.environment}"
+  recovery_window_in_days = var.environment == "prod" ? 30 : 0
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ga-tracking-id"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "ga_tracking_id" {
+  count         = var.secrets.ga_tracking_id != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.ga_tracking_id.id
+  secret_string = var.secrets.ga_tracking_id
+}
+
+resource "aws_secretsmanager_secret" "mapbox_user" {
+  name                    = "${var.project_name}/${var.environment}/mapbox-user"
+  description             = "Mapbox username for ${var.project_name} ${var.environment}"
+  recovery_window_in_days = var.environment == "prod" ? 30 : 0
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-mapbox-user"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "mapbox_user" {
+  count         = var.secrets.mapbox_user != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.mapbox_user.id
+  secret_string = var.secrets.mapbox_user
+}
+
+# IAM role for accessing secrets (for CI/CD pipeline)
+resource "aws_iam_role" "secrets_access" {
+  name = "${var.project_name}-${var.environment}-secrets-access"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = ["codebuild.amazonaws.com", "ecs-tasks.amazonaws.com"]
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "secrets_access" {
+  name = "${var.project_name}-${var.environment}-secrets-policy"
+  role = aws_iam_role.secrets_access.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          aws_secretsmanager_secret.mapbox_api_token.arn,
+          aws_secretsmanager_secret.ga_tracking_id.arn,
+          aws_secretsmanager_secret.mapbox_user.arn
+        ]
+      }
+    ]
+  })
+}

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -1,0 +1,13 @@
+output "secret_arns" {
+  description = "ARNs of all secrets"
+  value = {
+    mapbox_api_token = aws_secretsmanager_secret.mapbox_api_token.arn
+    ga_tracking_id   = aws_secretsmanager_secret.ga_tracking_id.arn
+    mapbox_user      = aws_secretsmanager_secret.mapbox_user.arn
+  }
+}
+
+output "secrets_access_role_arn" {
+  description = "ARN of the IAM role for accessing secrets"
+  value       = aws_iam_role.secrets_access.arn
+}

--- a/terraform/modules/secrets/variables.tf
+++ b/terraform/modules/secrets/variables.tf
@@ -1,0 +1,19 @@
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "secrets" {
+  description = "Map of secrets to store"
+  type = object({
+    mapbox_api_token = string
+    ga_tracking_id   = string
+    mapbox_user      = string
+  })
+  sensitive = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,35 @@
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = module.static_hosting.s3_bucket_name
+}
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront distribution ID"
+  value       = module.static_hosting.cloudfront_distribution_id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = module.static_hosting.cloudfront_domain_name
+}
+
+output "website_url" {
+  description = "Website URL"
+  value       = var.domain_name != null ? "https://${var.domain_name}" : module.static_hosting.cloudfront_domain_name
+}
+
+output "route53_zone_id" {
+  description = "Route 53 hosted zone ID"
+  value       = var.domain_name != null ? module.route53[0].zone_id : null
+}
+
+output "route53_name_servers" {
+  description = "Route 53 name servers"
+  value       = var.domain_name != null ? module.route53[0].name_servers : null
+}
+
+output "secrets_manager_arns" {
+  description = "ARNs of secrets in Secrets Manager"
+  value       = module.secrets.secret_arns
+  sensitive   = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,52 @@
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+  default     = "community-resource-explorer"
+}
+
+variable "environment" {
+  description = "Environment name (dev, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "Environment must be either 'dev' or 'prod'."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "price_class" {
+  description = "CloudFront price class"
+  type        = string
+  default     = "PriceClass_100"
+}
+
+variable "domain_name" {
+  description = "Domain name for the application"
+  type        = string
+  default     = null
+}
+
+variable "mapbox_api_token" {
+  description = "Mapbox API token for maps functionality"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "ga_tracking_id" {
+  description = "Google Analytics tracking ID"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "mapbox_user" {
+  description = "Mapbox username"
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
### This PR introduces Terraform configuration to provision and manage the AWS infrastructure for the Community Resource Explorer (CRE)

### Key Components:
S3 bucket for static website hosting
CloudFront CDN distribution with HTTPS
Route 53 DNS configuration
AWS Secrets Manager for sensitive configuration

**Monitoring & Alerting:**
CloudWatch Alarms for S3 and CloudFront
Budget alerts for cost monitoring

**Environment Structure:**
Separate configurations for dev and prod environments
Environment-specific variables and outputs
Example configuration files included

**Security:**
All sensitive values (Mapbox tokens, GA tracking ID) are managed via AWS Secrets Manager
S3 buckets are configured with appropriate access controls

**How to Deploy:**
Set up AWS credentials with appropriate permissions
Update terraform.tfvars in the respective environment directory
Run terraform init and terraform apply

Note:
This is part one of multiple PRs. Decided to split them up for easier review as well as testing.
